### PR TITLE
Add a flag to force Bazel to download certain artifacts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -574,6 +574,16 @@ public final class RemoteOptions extends OptionsBase {
       help = "Maximum number of open files allowed during BEP artifact upload.")
   public int maximumOpenFiles;
 
+  @Option(
+          name = "experimental_force_downloads_regex",
+          defaultValue = "",
+          documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+          effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+          help = "Force Bazel to download the artifacts that match the given regexp. To be used in conjunction with" +
+                  "--remote_download_minimal to allow the client to request certain artifacts that might be needed" +
+                  "locally (e.g. IDE support)")
+  public String experimentalForceDownloadsRegex;
+
   // The below options are not configurable by users, only tests.
   // This is part of the effort to reduce the overall number of flags.
 

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3154,6 +3154,65 @@ EOF
   expect_log "2 processes: 1 internal, 1 remote"
 }
 
+function test_forced_downloads() {
+  mkdir -p a
+
+  cat > a/BUILD <<'EOF'
+java_library(
+    name = "lib",
+    srcs = ["Library.java"],
+)
+
+java_test(
+    name = "test",
+    srcs = ["JavaTest.java"],
+    test_class = "JavaTest",
+    deps = [":lib"],
+)
+EOF
+
+  cat > a/Library.java <<'EOF'
+public class Library {
+  public static boolean TEST = true;
+}
+EOF
+
+  cat > a/JavaTest.java <<'EOF'
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JavaTest {
+    @Test
+    public void test() { Assert.assertTrue(Library.TEST); }
+}
+EOF
+  bazel test \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_download_minimal \
+      //a:test >& $TEST_log || fail "Failed to build"
+
+  [[ ! -e "bazel-bin/a/liblib.jar" ]] || fail "bazel-bin/a/liblib.jar shouldn't exist"
+  [[ ! -e "bazel-bin/a/liblib.jdeps" ]] || fail "bazel-bin/a/liblib.jdeps shouldn't exist"
+
+  bazel clean && bazel test \
+        --remote_executor=grpc://localhost:${worker_port} \
+        --remote_download_minimal \
+        --experimental_force_downloads_regex=".*" \
+        //a:test >& $TEST_log || fail "Failed to build"
+
+  [[ -e "bazel-bin/a/liblib.jar" ]] || fail "bazel-bin/a/liblib.jar file does not exist!"
+  [[ -e "bazel-bin/a/liblib.jdeps" ]] || fail "bazel-bin/a/liblib.jdeps file does not exist!"
+
+  bazel clean && bazel test \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_download_minimal \
+    --experimental_force_downloads_regex=".*jar$" \
+    //a:test >& $TEST_log || fail "Failed to build"
+
+  [[ -e "bazel-bin/a/liblib.jar" ]] || fail "bazel-bin/a/liblib.jar file does not exist!"
+  [[ ! -e "bazel-bin/a/liblib.jdeps" ]] || fail "bazel-bin/a/liblib.jdeps shouldn't exist"
+}
+
 function test_grpc_connection_errors_are_propagated() {
   # Test that errors when creating grpc connection are propagated instead of crashing Bazel.
   # https://github.com/bazelbuild/bazel/issues/13724


### PR DESCRIPTION
When using --remote_download_minimal Bazel only downloads to the client the minimum number of artifacts necessary for the build to succeed. This can be sometimes problematic when local development (i.e. IDE) requires some artifacts to do local work (e.g. syntax completion). We add a flag --experimental_force_downloads_regex that allow specifying a regular expression that will force certain artifacts to be forced to downloaded.

Tested locally that syntax errors disappear in IntelliJ when compiling Bazel itself with --remote_download_minimal and --experimental_force_downloads_regex=".*jar$", also included an integration test with several cases.

Signed-off-by: Luis Fernando Pino Duque [luis@engflow.com](mailto:luis@engflow.com)